### PR TITLE
fix doxygen build action

### DIFF
--- a/.github/workflows/doxygen-pages.yml
+++ b/.github/workflows/doxygen-pages.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build and Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@main
         with:
@@ -29,7 +29,7 @@ jobs:
           echo '::echo::on'
           echo "PROJECT_NUMBER = `git describe --tags`" >> ./docs/doxygen/Doxyfile
       - run: |
-          sudo apt install libclang1-9 libclang-cpp9
+          sudo apt install libclang1-11 libclang-cpp11
           sudo apt-get install -y graphviz
           wget -O doxygen.tar.gz https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz/download
           mkdir doxy-bin

--- a/.github/workflows/doxygen-pages.yml
+++ b/.github/workflows/doxygen-pages.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build and Setup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@main
         with:
@@ -29,7 +29,7 @@ jobs:
           echo '::echo::on'
           echo "PROJECT_NUMBER = `git describe --tags`" >> ./docs/doxygen/Doxyfile
       - run: |
-          sudo apt install libclang1-11 libclang-cpp11
+          sudo apt install libclang1-9 libclang-cpp9
           sudo apt-get install -y graphviz
           wget -O doxygen.tar.gz https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz/download
           mkdir doxy-bin


### PR DESCRIPTION
Specify ubuntu 20.04 so that libclang-9 can always be used successfully